### PR TITLE
Fixed bit manipulation in AdditionalWhitePointDescriptor.cs and DetailedTimingDescriptor.cs

### DIFF
--- a/EDIDParser/Descriptors/AdditionalWhitePointDescriptor.cs
+++ b/EDIDParser/Descriptors/AdditionalWhitePointDescriptor.cs
@@ -34,7 +34,7 @@ namespace EDIDParser.Descriptors
         }
 
         /// <summary>
-        ///     Gets the gamma value (1.0–3.54)
+        ///     Gets the gamma value (1.0-3.54)
         /// </summary>
         public double Gamma
         {
@@ -89,7 +89,7 @@ namespace EDIDParser.Descriptors
                     throw new InvalidDescriptorException("The provided data does not belong to this descriptor.");
                 var least = (int) Reader.ReadInt(Offset + _internalOffset + 1, 2, 2);
                 var most = (int) Reader.ReadByte(Offset + _internalOffset + 2);
-                return (most*4 + least)/1024d;
+                return ((most << 2) | least)/1024d;
             }
         }
 
@@ -104,7 +104,7 @@ namespace EDIDParser.Descriptors
                     throw new InvalidDescriptorException("The provided data does not belong to this descriptor.");
                 var least = (int) Reader.ReadInt(Offset + _internalOffset + 1, 0, 2);
                 var most = (int) Reader.ReadByte(Offset + _internalOffset + 3);
-                return (most*4 + least)/1024d;
+                return ((most << 2) | least)/1024d;
             }
         }
 

--- a/EDIDParser/Descriptors/DetailedTimingDescriptor.cs
+++ b/EDIDParser/Descriptors/DetailedTimingDescriptor.cs
@@ -24,7 +24,7 @@ namespace EDIDParser.Descriptors
                     throw new InvalidDescriptorException("The provided data does not belong to this descriptor.");
                 var least = (uint) Reader.ReadByte(Offset + 2);
                 var most = (uint) Reader.ReadInt(Offset + 4, 4, 4);
-                return most*16 + least;
+                return (most << 8) | least;
             }
         }
 
@@ -39,7 +39,7 @@ namespace EDIDParser.Descriptors
                     throw new InvalidDescriptorException("The provided data does not belong to this descriptor.");
                 var least = (uint) Reader.ReadByte(Offset + 3);
                 var most = (uint) Reader.ReadInt(Offset + 4, 0, 4);
-                return most*16 + least;
+                return (most << 8) | least;
             }
         }
 
@@ -67,7 +67,7 @@ namespace EDIDParser.Descriptors
                     throw new InvalidDescriptorException("The provided data does not belong to this descriptor.");
                 var least = (uint) Reader.ReadByte(Offset + 12);
                 var most = (uint) Reader.ReadInt(Offset + 14, 4, 4);
-                return most*16 + least;
+                return (most << 8) | least;
             }
         }
 
@@ -82,7 +82,7 @@ namespace EDIDParser.Descriptors
                     throw new InvalidDescriptorException("The provided data does not belong to this descriptor.");
                 var least = (uint) Reader.ReadByte(Offset + 8);
                 var most = (uint) Reader.ReadInt(Offset + 11, 6, 2);
-                return most*8 + least;
+                return (most << 8) | least;
             }
         }
 
@@ -113,7 +113,7 @@ namespace EDIDParser.Descriptors
                     throw new InvalidDescriptorException("The provided data does not belong to this descriptor.");
                 var least = (uint) Reader.ReadByte(Offset + 9);
                 var most = (uint) Reader.ReadInt(Offset + 11, 4, 2);
-                return most*8 + least;
+                return (most << 8) | least;
             }
         }
 
@@ -216,7 +216,7 @@ namespace EDIDParser.Descriptors
                     throw new InvalidDescriptorException("The provided data does not belong to this descriptor.");
                 var least = (uint) Reader.ReadByte(Offset + 5);
                 var most = (uint) Reader.ReadInt(Offset + 7, 4, 4);
-                return most*16 + least;
+                return (most << 8) | least;
             }
         }
 
@@ -231,7 +231,7 @@ namespace EDIDParser.Descriptors
                     throw new InvalidDescriptorException("The provided data does not belong to this descriptor.");
                 var least = (uint) Reader.ReadByte(Offset + 6);
                 var most = (uint) Reader.ReadInt(Offset + 7, 0, 4);
-                return most*16 + least;
+                return (most << 8) | least;
             }
         }
 
@@ -259,7 +259,7 @@ namespace EDIDParser.Descriptors
                     throw new InvalidDescriptorException("The provided data does not belong to this descriptor.");
                 var least = (uint) Reader.ReadByte(Offset + 13);
                 var most = (uint) Reader.ReadInt(Offset + 14, 0, 4);
-                return most*16 + least;
+                return (most << 8) | least;
             }
         }
 
@@ -274,7 +274,7 @@ namespace EDIDParser.Descriptors
                     throw new InvalidDescriptorException("The provided data does not belong to this descriptor.");
                 var least = (uint) Reader.ReadInt(Offset + 10, 4, 4);
                 var most = (uint) Reader.ReadInt(Offset + 11, 2, 2);
-                return most*8 + least;
+                return (most << 4) | least;
             }
         }
 
@@ -305,7 +305,7 @@ namespace EDIDParser.Descriptors
                     throw new InvalidDescriptorException("The provided data does not belong to this descriptor.");
                 var least = (uint) Reader.ReadInt(Offset + 10, 0, 4);
                 var most = (uint) Reader.ReadInt(Offset + 11, 0, 2);
-                return most*8 + least;
+                return (most << 4) | least;
             }
         }
 


### PR DESCRIPTION
Output when parsing an EDID with a 3840x2160 DetailedTimingDescriptor before (notice the incorrect `HorizontalActivePixels` and `VerticalActivePixels` values):
```

   EDID.Descriptors
________________________________________________________________________________________________________________________
[0]: {
   HorizontalActivePixels: 240
   HorizontalBlankingPixels: 160
   HorizontalBorderPixels: 0
   HorizontalDisplaySize: 192
   HorizontalSyncOffset: 48
   HorizontalSyncPolarity: Positive
   HorizontalSyncPulse: 32
   IsInterlaced: False
   IsSyncOnAllRGBLines: EDIDParser.Exceptions.DigitalDisplayException
   IsValid: True
   IsVerticalSyncSerrated: EDIDParser.Exceptions.DigitalDisplayException
   PixelClock: 533250000
   StereoMode: NoStereo
   SyncType: DigitalSeparate
   VerticalActivePixels: 240
   VerticalBlankingPixels: 62
   VerticalBorderPixels: 0
   VerticalDisplaySize: 168
   VerticalSyncOffset: 3
   VerticalSyncPolarity: Positive
   VerticalSyncPulse: 5
```

Output after:

```
   EDID.Descriptors
________________________________________________________________________________________________________________________
[0]: {
   HorizontalActivePixels: 3840
   HorizontalBlankingPixels: 160
   HorizontalBorderPixels: 0
   HorizontalDisplaySize: 1152
   HorizontalSyncOffset: 48
   HorizontalSyncPolarity: Positive
   HorizontalSyncPulse: 32
   IsInterlaced: False
   IsSyncOnAllRGBLines: EDIDParser.Exceptions.DigitalDisplayException
   IsValid: True
   IsVerticalSyncSerrated: EDIDParser.Exceptions.DigitalDisplayException
   PixelClock: 533250000
   StereoMode: NoStereo
   SyncType: DigitalSeparate
   VerticalActivePixels: 2160
   VerticalBlankingPixels: 62
   VerticalBorderPixels: 0
   VerticalDisplaySize: 648
   VerticalSyncOffset: 3
   VerticalSyncPolarity: Positive
   VerticalSyncPulse: 5
},
[1]: {
   IsValid: True
   Type: MonitorName
   Value: 0063400000
},
```